### PR TITLE
Tooltip Fixes and Consistency

### DIFF
--- a/src/BetterAttributes/Patches/AttributeVMPatches.cs
+++ b/src/BetterAttributes/Patches/AttributeVMPatches.cs
@@ -46,19 +46,19 @@ namespace BetterAttributes.Patches {
                 aplicableBonuses.Add(new CustomAtrObject(ca, "Increases stagger interrupt by " + (Helper.settings.staggerBonus * lvl).ToString("P") + "", Helper.settings.staggerBonusPlayerOnly));
 
             if (Helper.GetAttributeTypeFromText(Helper.settings.simBonusAttribute) == ca && Helper.settings.simBonusEnabled)
-                aplicableBonuses.Add(new CustomAtrObject(ca, "Increases simulation by " + (Helper.settings.simBonus * lvl).ToString("P") + "", Helper.settings.simBonusPlayerOnly));
+                aplicableBonuses.Add(new CustomAtrObject(ca, "Increases simulation advantage by " + (Helper.settings.simBonus * lvl).ToString("P") + "", Helper.settings.simBonusPlayerOnly));
 
             if (Helper.GetAttributeTypeFromText(Helper.settings.persuasionBonusAttribute) == ca && Helper.settings.persuasionBonusEnabled)
-                aplicableBonuses.Add(new CustomAtrObject(ca, "Increases persuasion by " + (Helper.settings.persuasionBonus * lvl).ToString("P") + "", true));
+                aplicableBonuses.Add(new CustomAtrObject(ca, "Increases persuasion chance by " + (Helper.settings.persuasionBonus * lvl).ToString("P") + "", true));
 
             if (Helper.GetAttributeTypeFromText(Helper.settings.renownBonusAttribute) == ca && Helper.settings.renownBonusEnabled)
                 aplicableBonuses.Add(new CustomAtrObject(ca, "Increases renown earned from victories by " + (Helper.settings.renownBonus * lvl).ToString("P") + "", Helper.settings.renownBonusPlayerOnly));
 
             if (Helper.GetAttributeTypeFromText(Helper.settings.moraleBonusAttribute) == ca && Helper.settings.moraleBonusEnabled)
-                aplicableBonuses.Add(new CustomAtrObject(ca, "Increases moral earned from victories by " + (Helper.settings.moraleBonus * lvl).ToString("P") + "", Helper.settings.moraleBonusPlayerOnly));
+                aplicableBonuses.Add(new CustomAtrObject(ca, "Increases morale earned from victories by " + (Helper.settings.moraleBonus * lvl).ToString("P") + "", Helper.settings.moraleBonusPlayerOnly));
 
             if (Helper.GetAttributeTypeFromText(Helper.settings.partyMoraleBonusAttribute) == ca && Helper.settings.partyMoraleBonusEnabled)
-                aplicableBonuses.Add(new CustomAtrObject(ca, "Increases party moral by " + (Helper.settings.partyMoraleBonus * lvl).ToString("P") + "", Helper.settings.partyMoraleBonusPlayerOnly));
+                aplicableBonuses.Add(new CustomAtrObject(ca, "Increases party morale by " + (Helper.settings.partyMoraleBonus * lvl).ToString("P") + "", Helper.settings.partyMoraleBonusPlayerOnly));
 
             if (Helper.GetAttributeTypeFromText(Helper.settings.wageBonusAttribute) == ca && Helper.settings.wageBonusEnabled)
                 aplicableBonuses.Add(new CustomAtrObject(ca, "Decreases party wages by " + (Helper.settings.wageBonus * lvl).ToString("P") + "", Helper.settings.wageBonusPlayerOnly));
@@ -67,7 +67,7 @@ namespace BetterAttributes.Patches {
                 aplicableBonuses.Add(new CustomAtrObject(ca, "Increases party size by " + (Helper.settings.partySizeBonus * lvl).ToString("P") + "", Helper.settings.partySizeBonusPlayerOnly));
 
             if (Helper.GetAttributeTypeFromText(Helper.settings.incomeBonusAttribute) == ca && Helper.settings.incomeBonusEnabled)
-                aplicableBonuses.Add(new CustomAtrObject(ca, "Increases gross income by " + (Helper.settings.incomeBonus * lvl).ToString("P") + "", Helper.settings.incomeBonusPlayerOnly));
+                aplicableBonuses.Add(new CustomAtrObject(ca, "Increases gross clan income by " + (Helper.settings.incomeBonus * lvl).ToString("P") + "", Helper.settings.incomeBonusPlayerOnly));
 
             if (Helper.GetAttributeTypeFromText(Helper.settings.influenceBonusAttribute) == ca && Helper.settings.influenceBonusEnabled)
                 aplicableBonuses.Add(new CustomAtrObject(ca, "Increases influence earned from victories by " + (Helper.settings.influenceBonus * lvl).ToString("P") + "", Helper.settings.influenceBonusPlayerOnly));

--- a/src/BetterAttributes/Settings/DefaultSettings.cs
+++ b/src/BetterAttributes/Settings/DefaultSettings.cs
@@ -13,7 +13,7 @@ namespace BetterAttributes.Settings {
 
         public bool healthBonusEnabled { get; set; } = true;
         public bool healthBonusPlayerOnly { get; set; } = true;
-        public float healthBonus { get; set; } = 0.02f;
+        public float healthBonus { get; set; } = 0.05f;
         public string healthBonusAttribute { get; set; } = "Endurance";
 
         public bool staggerBonusEnabled { get; set; } = true;
@@ -67,7 +67,7 @@ namespace BetterAttributes.Settings {
 
         public bool xpBonusEnabled { get; set; } = true;
         public bool xpBonusPlayerOnly { get; set; } = true;
-        public float xpBonus { get; set; } = 0.02f;
+        public float xpBonus { get; set; } = 0.05f;
         public string xpBonusAttribute { get; set; } = "Intelligence";
 
         public bool partyLeaderXPBonusEnabled { get; set; } = true;

--- a/src/BetterAttributes/Settings/MCMSettings.cs
+++ b/src/BetterAttributes/Settings/MCMSettings.cs
@@ -13,7 +13,7 @@ namespace BetterAttributes.Settings {
         const string enabledDesText = "{=BA_sVRwEA}Should bonuses be applied.";
 
         const string playerOnlyText = "{=BA_vBH4P5}Player Only";
-        const string playerOnlyDesText = "{=BA_5AKRK0}Determines if this bonus applies to all heroes, not just the player.";
+        const string playerOnlyDesText = "{=BA_5AKRK0}Should this bonus apply to all heroes, not just the player.";
 
         const string bonusText = "{=BA_8g0U40}Bonus";
         const string genericBonusText = "{=BA_3F0Jal}An increase multiplied by attribute level. (For example, a 2% (.02) bonus will be 20% at attribute level 10)";
@@ -55,7 +55,7 @@ namespace BetterAttributes.Settings {
         }, selectedIndex: 0);
 
 
-        const string rangeText = "{=BA_qDobnE}Range Damage Bonus";
+        const string rangeText = "{=BA_qDobnE}Ranged Damage Bonus";
 
         [SettingPropertyGroup(bonusesText + "/" + rangeText)]
         [SettingPropertyBool(enabledText, Order = 0, RequireRestart = false, IsToggle = true, HintText = enabledDesText)]
@@ -81,7 +81,7 @@ namespace BetterAttributes.Settings {
         }, selectedIndex: 1);
 
 
-        const string healthText = "{=BA_naGmUB}Health Bonus";
+        const string healthText = "{=BA_naGmUB}Health (HP) Bonus";
 
         [SettingPropertyGroup(bonusesText + "/" + healthText)]
         [SettingPropertyBool(enabledText, Order = 0, RequireRestart = false, IsToggle = true, HintText = enabledDesText)]
@@ -133,7 +133,7 @@ namespace BetterAttributes.Settings {
         }, selectedIndex: 2);
 
 
-        const string simText = "{=BA_7yzj1P}Simulation Bonus";
+        const string simText = "{=BA_7yzj1P}Simulation Advantage Bonus";
 
         [SettingPropertyGroup(bonusesText + "/" + simText)]
         [SettingPropertyBool(enabledText, Order = 0, RequireRestart = false, IsToggle = true, HintText = enabledDesText)]
@@ -159,7 +159,7 @@ namespace BetterAttributes.Settings {
         }, selectedIndex: 3);
 
 
-        const string persuasionText = "{=BA_zH5MWH}Persuasion Bonus";
+        const string persuasionText = "{=BA_zH5MWH}Persuasion Chance Bonus";
 
         [SettingPropertyGroup(bonusesText + "/" + persuasionText)]
         [SettingPropertyBool(enabledText, Order = 0, RequireRestart = false, IsToggle = true, HintText = enabledDesText)]
@@ -312,7 +312,7 @@ namespace BetterAttributes.Settings {
 
 
 
-        const string incomeText = "{=BA_GINfAP}Clan Income Bonus";
+        const string incomeText = "{=BA_GINfAP}Gross Clan Income Bonus";
 
         [SettingPropertyGroup(bonusesText + "/" + incomeText)]
         [SettingPropertyBool(enabledText, Order = 0, RequireRestart = false, IsToggle = true, HintText = enabledDesText)]
@@ -390,7 +390,7 @@ namespace BetterAttributes.Settings {
         }, selectedIndex: 5);
 
 
-        const string partyLeaderXPText = "{=BA_354j0f}Party Leader XP From Party Roles";
+        const string partyLeaderXPText = "{=BA_354j0f}Party Leader XP From Assigned Party Roles";
 
         [SettingPropertyGroup(bonusesText + "/" + partyLeaderXPText)]
         [SettingPropertyBool(enabledText, Order = 0, RequireRestart = false, IsToggle = true, HintText = "Should the party leader be granted bonus xp from assigned party roles. For example, if your scout gains some xp in scouting how much of the xp should be granted to the party leader.")]
@@ -412,7 +412,7 @@ namespace BetterAttributes.Settings {
         }, selectedIndex: 5);
 
 
-        const string companionText = "{=BA_354j0f}Companion Bonus";
+        const string companionText = "{=BA_354j0f}Companion Limit Bonus";
 
         [SettingPropertyGroup(bonusesText + "/" + companionText)]
         [SettingPropertyBool(enabledText, Order = 0, RequireRestart = false, IsToggle = true, HintText = enabledDesText)]
@@ -435,7 +435,7 @@ namespace BetterAttributes.Settings {
 
 
         [SettingPropertyGroup(attributeText)]
-        [SettingPropertyInteger("{=BA_GU6Ibm}Levels Per Attribute Points", 0, 10, "0", Order = 0, RequireRestart = false, HintText = "{=BA_VhEAx3}How many levels you need to gain to get an attribute point.")]
+        [SettingPropertyInteger("{=BA_GU6Ibm}Levels Per Attribute Point", 0, 10, "0", Order = 0, RequireRestart = false, HintText = "{=BA_VhEAx3}How many levels you need to gain to get an attribute point.")]
         public int levelsPerAttributePoint { get; set; } = 3;
 
         [SettingPropertyGroup(attributeText)]
@@ -447,7 +447,7 @@ namespace BetterAttributes.Settings {
         public int focusPointsPerLevel { get; set; } = 1;
 
         [SettingPropertyGroup("Focus")]
-        [SettingPropertyInteger("{=BA_S7nfeK}Max Points Per Skill", 0, 100, "0", Order = 0, RequireRestart = false, HintText = "{=BA_GtIutr}How many focus points that can be spent on a skill.")]
+        [SettingPropertyInteger("{=BA_S7nfeK}Max Focus Points Per Skill", 0, 100, "0", Order = 0, RequireRestart = false, HintText = "{=BA_GtIutr}How many focus points that can be spent on a skill.")]
         public int maxFocusPointsPerSkill { get; set; } = 5;
 
 


### PR DESCRIPTION
Fixed tooltip consistency and clarity both for in-game tooltips and the MCM ones.
I believe I caught all of the tooltips in the code.

Minor change to default settings for HP and XP from 2% to 5% per attribute.
Should provide a better baseline for the majority of users.