### PR TITLE
Small bugfix to Stagger Interrupt String

### DIFF
--- a/BetterAttributes/Patches/CharacterAttributeItemVMPatch.cs
+++ b/BetterAttributes/Patches/CharacterAttributeItemVMPatch.cs
@@ -46,7 +46,7 @@ namespace BetterAttributes.Patches {
             TextObject rngDmgText = new TextObject(Strings.RngBonusText);
             TextObject healthText = new TextObject(Strings.HealthBonusText);
             TextObject healthRegenText = new TextObject(Strings.HealthRegenBonusText);
-            TextObject staggerText = new TextObject(Strings.StabilityBonusText);
+            TextObject staggerText = new TextObject(Strings.StaggerBonusText);
             TextObject simText = new TextObject(Strings.SimBonusText);
             TextObject persuasionText = new TextObject(Strings.PersuasionBonusText);
             TextObject renownText = new TextObject(Strings.RenownBonusText);

--- a/BetterAttributes/Strings.cs
+++ b/BetterAttributes/Strings.cs
@@ -78,7 +78,7 @@
         public const string SmithingBonusText = "{=BA_OpKSII}Increases smithing stamina by ";
         public const string AccuracyBonusText = "{=BA_3dclGJ}Increases accuracy by ";
         public const string DrawBonusText = "{=BA_X0m4Om}Increases draw speed by ";
-        public const string StabilityBonusText = "{=BA_r5Y7lw}Increases stability by ";
+        public const string StabilityBonusText = "{=BA_r5Y7lw}Increases aim stability by ";
         public const string SliceBonusText = "{=BA_capoto}Slice through chance ";
         public const string CrushBonusText = "{=BA_gn38sf}Crush through chance ";
 

--- a/BetterAttributes/_Module/ModuleData/Languages/std_ba_strings_xml.xml
+++ b/BetterAttributes/_Module/ModuleData/Languages/std_ba_strings_xml.xml
@@ -80,7 +80,7 @@
 		<string id="BA_OpKSII" text="Increases smithing stamina by "/>
 		<string id="BA_3dclGJ" text="Increases accuracy by "/>
 		<string id="BA_X0m4Om" text="Increases draw speed by "/>
-		<string id="BA_r5Y7lw" text="Increases stability by "/>
+		<string id="BA_r5Y7lw" text="Increases aim stability by "/>
 		<string id="BA_capoto" text="Slice through chance "/>
 	</strings>
 </base>


### PR DESCRIPTION
Stagger interrupt was incorrectly using the StabilityBonusText string instead of StaggerBonusText. As a result, both had the same tooltip on attributes.

Also changed "stability" to "aim stability" to be consistent with the MCM Settings to avoid confusion.